### PR TITLE
Initial version of namespace filter plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+sudo: false
+language: go
+go:
+- 1.5.3
+- 1.6
+before_install:
+- go get github.com/tools/godep
+- if [ ! -d $SNAP_PLUGIN_SOURCE ]; then mkdir -p $HOME/gopath/src/github.com/intelsdi-x; ln -s $TRAVIS_BUILD_DIR $SNAP_PLUGIN_SOURCE; fi # CI for forks not from intelsdi-x
+env:
+  global:
+    - SNAP_PLUGIN_SOURCE=/home/travis/gopath/src/github.com/intelsdi-x/snap-plugin-collector-psutil
+  matrix:
+    - TEST=unit
+install:
+- export TMPDIR=$HOME/tmp
+- mkdir -p $TMPDIR
+- cd $SNAP_PLUGIN_SOURCE # change dir into source
+- make deps
+script:
+- make check TEST=$TEST 2>&1 # Run test suite
+notifications:
+  slack:
+    secure: VkbZLIc2RH8yf3PtIAxUNPdAu3rQQ7yQx0GcK124JhbEnZGaHyK615V0rbG7HcVmYKGPdB0cXqZiLBDKGqGKb2zR1NepOe1nF03jxGSpPq8jIFeEXSJGEYGL34ScDzZZGuG6qwbjFcXiW5lqn6t8igzp7v2+URYBaZo5ktCS2xY=

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# snap processor plugin - ns-filter
+
+1. [Contributing Code](#contributing-code)
+2. [Contribute Elsewhere](#contribute-elsewhere)
+3. [Thank You](#thank-you)
+
+This repository has dedicated developers from Intel working on updates. The most helpful way to contribute is by reporting your experience through issues. Issues may not be updated while we review internally, but they're still incredibly appreciated.
+
+## Contributing Code
+**_IMPORTANT_**: We encourage contributions to the project from the community. We ask that you keep the following guidelines in mind when planning your contribution.
+
+* Whether your contribution is for a bug fix or a feature request, **create an [Issue](https://github.com/snap-plugin-processor-ns-filter/issues)** and let us know what you are thinking
+* **For bugs**, if you have already found a fix, feel free to submit a Pull Request referencing the Issue you created
+* **For feature requests**, we want to improve upon the library incrementally which means small changes at a time. In order ensure your PR can be reviewed in a timely manner, please keep PRs small, e.g. <10 files and <500 lines changed. If you think this is unrealistic, then mention that within the issue and we can discuss it
+
+Once you're ready to contribute code back to this repo, start with these steps:
+
+* Fork the appropriate sub-projects that are affected by your change
+* Clone the fork to `$GOPATH/src/github.com/intelsdi-x/`
+	```
+	$ git clone https://github.com/<yourGithubID>/<project>.git
+	```
+* Create a topic branch for your change and checkout that branch  
+    ```
+    $ git checkout -b some-topic-branch
+    ```
+* Make your changes and run the test suite if one is provided (see below)
+* Commit your changes and push them to your fork
+* Open a pull request for the appropriate project
+* Contributors will review your pull request, suggest changes, and merge it when it’s ready and/or offer feedback
+* To report a bug or issue, please open a new issue against this repository
+
+If you have questions feel free to contact the [maintainers](https://github.com/intelsdi-x/snap/blob/master/README.md#maintainers).
+
+## Contribute Elsewhere
+This repository is one of **many** plugins in **snap**, a powerful telemetry framework. See the full project at http://github.com/intelsdi-x/snap
+
+## Thank You
+And **thank you!** Your contribution, through code and participation, is incredibly important to us.

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,0 +1,80 @@
+{
+	"ImportPath": "github.com/intelsdi-x/snap-plugin-processor-ns-filter",
+	"GoVersion": "go1.6",
+	"GodepVersion": "v62",
+	"Deps": [
+		{
+			"ImportPath": "github.com/Sirupsen/logrus",
+			"Comment": "v0.10.0-16-gcd7d1bb",
+			"Rev": "cd7d1bbe41066b6c1f19780f895901052150a575"
+		},
+		{
+			"ImportPath": "github.com/intelsdi-x/snap/control/plugin",
+			"Comment": "v0.13.0-beta-131-g4d7d4ca",
+			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
+		},
+		{
+			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/cpolicy",
+			"Comment": "v0.13.0-beta-131-g4d7d4ca",
+			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
+		},
+		{
+			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/encoding",
+			"Comment": "v0.13.0-beta-131-g4d7d4ca",
+			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
+		},
+		{
+			"ImportPath": "github.com/intelsdi-x/snap/control/plugin/encrypter",
+			"Comment": "v0.13.0-beta-131-g4d7d4ca",
+			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
+		},
+		{
+			"ImportPath": "github.com/intelsdi-x/snap/core",
+			"Comment": "v0.13.0-beta-131-g4d7d4ca",
+			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
+		},
+		{
+			"ImportPath": "github.com/intelsdi-x/snap/core/cdata",
+			"Comment": "v0.13.0-beta-131-g4d7d4ca",
+			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
+		},
+		{
+			"ImportPath": "github.com/intelsdi-x/snap/core/ctypes",
+			"Comment": "v0.13.0-beta-131-g4d7d4ca",
+			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
+		},
+		{
+			"ImportPath": "github.com/intelsdi-x/snap/core/serror",
+			"Comment": "v0.13.0-beta-131-g4d7d4ca",
+			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
+		},
+		{
+			"ImportPath": "github.com/intelsdi-x/snap/pkg/ctree",
+			"Comment": "v0.13.0-beta-131-g4d7d4ca",
+			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
+		},
+		{
+			"ImportPath": "github.com/intelsdi-x/snap/pkg/schedule",
+			"Comment": "v0.13.0-beta-131-g4d7d4ca",
+			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
+		},
+		{
+			"ImportPath": "github.com/intelsdi-x/snap/scheduler/wmap",
+			"Comment": "v0.13.0-beta-131-g4d7d4ca",
+			"Rev": "4d7d4ca909d51bfc21399536d3513a8bb49a35be"
+		},
+		{
+			"ImportPath": "github.com/robfig/cron",
+			"Comment": "v1-16-g0f39cf7",
+			"Rev": "0f39cf7ebc65a602f45692f9894bd6a193faf8fa"
+		},
+		{
+			"ImportPath": "golang.org/x/sys/unix",
+			"Rev": "c8bc69bc2db9c57ccf979550bc69655df5039a8a"
+		},
+		{
+			"ImportPath": "gopkg.in/yaml.v2",
+			"Rev": "c1cd2254a6dd314c9d73c338c12688c9325d85c6"
+		}
+	]
+}

--- a/Godeps/Readme
+++ b/Godeps/Readme
@@ -1,0 +1,5 @@
+This directory tree is generated automatically by godep.
+
+Please do not edit.
+
+See https://github.com/tools/godep for more information.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+default:
+	$(MAKE) deps
+	$(MAKE) all
+deps:
+	bash -c "godep restore"
+test:
+	bash -c "./scripts/test.sh $(TEST)"
+check:
+	$(MAKE) test
+all:
+	bash -c "./scripts/build.sh $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,94 @@
-# snap-plugin-processor-ns-filter
+# snap plugin processor - ns-filter
+snap plugin intended to remove unwanted namespace elements and turn them into tags.
+
+1. [Getting Started](#getting-started)
+  * [System Requirements](#system-requirements)
+  * [Installation](#installation)
+  * [Configuration and Usage](#configuration-and-usage)
+2. [Documentation](#documentation)
+  * [Examples](#examples)
+  * [Roadmap] (#roadmap)
+3. [Community Support](#community-support)
+4. [Contributing](#contributing)
+5. [License](#license)
+6. [Acknowledgements](#acknowledgements)
+
+### System Requirements
+* Plugin supports only Linux systems
+
+### Installation
+#### Download ns-filter plugin binary:
+You can get the pre-built binaries for your OS and architecture at snap's [Github Releases](https://github.com/intelsdi-x/snap/releases) page.
+
+#### To build the plugin binary:
+Fork https://github.com/intelsdi-x/snap-plugin-processor-ns-filter
+
+Clone repo into `$GOPATH/src/github/intelsdi-x/`:
+```
+$ git clone https://github.com/<yourGithubID>/snap-plugin-processor-ns-filter
+```
+Build the plugin by running make in repo:
+```
+$ make
+```
+This builds the plugin in `/build/rootfs`
+
+### Configuration and Usage
+* Set up the [snap framework](https://github.com/intelsdi-x/snap/blob/master/README.md#getting-started)
+* Ensure `$SNAP_PATH` is exported
+`export SNAP_PATH=$GOPATH/src/github.com/intelsdi-x/snap/build`
+
+## Documentation
+
+Ns-filter processor tries to compile provided regular expression from config item "expression" and match each namespace element to it.
+If namespace element matches, it will be removed from the metric namespace and turned into tag with key provided in config item "tag".
+
+
+### Examples
+```
+{
+    "version": 1,
+    "workflow": {
+        "collect": {
+            "metrics": {
+                "/intel/node-manager/1.1.1.2/temp": {}
+            },
+            "config": {},
+            "process": [
+                {
+                    "plugin_name": "ns-filter",
+                    "process": null,
+                    "publish": null,
+                    "config": {
+                        "expression": "([0-9]{1,3}\.){3}([0-9]{1,3})",
+                        "tag": "host_ip"
+                    }
+                }
+            ],
+            "publish": null
+        }
+    }
+}
+```
+
+### Roadmap
+There isn't a current roadmap for this plugin, but it is in active development. As we launch this plugin, we do not have any outstanding requirements for the next release.
+
+If you have a feature request, please add it as an [issue](https://github.com/intelsdi-x/snap-plugin-processor-ns-filter/issues/new) and/or submit a [pull request](https://github.com/intelsdi-x/snap-plugin-processor-ns-filter/pulls).
+
+## Community Support
+This repository is one of **many** plugins in **snap**, a powerful telemetry framework. See the full project at http://github.com/intelsdi-x/snap To reach out to other users, head to the [main framework](https://github.com/intelsdi-x/snap#community-support)
+
+## Contributing
+We love contributions!
+
+There's more than one way to give back, from examples to blogs to code updates. See our recommended process in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## License
+[snap](http://github.com:intelsdi-x/snap), along with this plugin, is an Open Source software released under the Apache 2.0 [License](LICENSE).
+
+## Acknowledgements
+
+* Author: [Marcin Krolik](https://github.com/marcin-krolik)
+
+And **thank you!** Your contribution, through code and participation, is incredibly important to us.

--- a/main.go
+++ b/main.go
@@ -1,0 +1,32 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+Copyright 2016 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+
+	"github.com/intelsdi-x/snap/control/plugin"
+
+	"github.com/intelsdi-x/snap-plugin-processor-ns-filter/processor"
+)
+
+func main() {
+	meta := processor.Meta()
+	plugin.Start(meta, processor.New(), os.Args[1])
+}

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -1,0 +1,116 @@
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+Copyright 2016 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package processor
+
+import (
+	"bytes"
+	"encoding/gob"
+	"fmt"
+	"regexp"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/intelsdi-x/snap/control/plugin"
+	"github.com/intelsdi-x/snap/control/plugin/cpolicy"
+	"github.com/intelsdi-x/snap/core/ctypes"
+)
+
+const (
+	// name of the processor plugin
+	pluginName = "ns-filter"
+	// version of the processor plugin
+	pluginVersion = 1
+	// type of the plugin
+	pluginType = plugin.ProcessorPluginType
+	// configuration error
+	errConfigurationNotProvided = "Required configuration item {%s} is not provided"
+	// regular experion compilation error
+	errRegexpCompilationError = "Could not compile provided expression {%s}, %s"
+)
+
+// New returns instance of MesosProcessor plugin
+func New() *Processor {
+	return &Processor{logger: log.New()}
+}
+
+// Meta returns a plugin meta data
+func Meta() *plugin.PluginMeta {
+	return plugin.NewPluginMeta(pluginName, pluginVersion, pluginType, []string{plugin.SnapGOBContentType}, []string{plugin.SnapGOBContentType})
+}
+
+// GetConfigPolicy returns config policy for MesosProcessor plugin
+func (p *Processor) GetConfigPolicy() (*cpolicy.ConfigPolicy, error) {
+	cp := cpolicy.New()
+	rule1, _ := cpolicy.NewStringRule("expression", true)
+	rule2, _ := cpolicy.NewStringRule("tag", true)
+	pnode := cpolicy.NewPolicyNode()
+	pnode.Add(rule1)
+	pnode.Add(rule2)
+	cp.Add([]string{"/"}, pnode)
+	return cp, nil
+}
+
+// Process calculates additional derived metrics based on raw metrics received
+func (p *Processor) Process(contentType string, content []byte, config map[string]ctypes.ConfigValue) (string, []byte, error) {
+
+	p.logger.Printf("%s Processor started {%s}", pluginName, contentType)
+	expression := config["expression"].(ctypes.ConfigValueStr).Value
+
+	re, err := regexp.Compile(expression)
+	if err != nil {
+		return contentType, nil, fmt.Errorf(errRegexpCompilationError, expression, err)
+	}
+
+	tag := config["tag"].(ctypes.ConfigValueStr).Value
+
+	var metrics []plugin.MetricType
+
+	//Decodes the content into pluginMetricType
+	dec := gob.NewDecoder(bytes.NewBuffer(content))
+	if err := dec.Decode(&metrics); err != nil {
+		p.logger.Printf("Error decoding: error=%v content=%v", err, content)
+		return "", nil, err
+	}
+
+	metrics = filter(metrics, re, tag)
+
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	enc.Encode(metrics)
+	return contentType, buf.Bytes(), nil
+}
+
+// Processor represents plugin for processing metrics retrieved from Mesos cluster
+type Processor struct {
+	logger *log.Logger
+}
+
+func filter(metrics []plugin.MetricType, re *regexp.Regexp, tag string) []plugin.MetricType {
+	for i := range metrics {
+		ns := metrics[i].Namespace()
+		for j, nsElement := range ns {
+			if re.MatchString(nsElement.Value) {
+				metrics[i].Namespace_ = append(ns[:j], ns[j+1:]...)
+				metrics[i].Tags()[tag] = nsElement.Value
+			}
+		}
+	}
+
+	return metrics
+}

--- a/processor/processor_small_test.go
+++ b/processor/processor_small_test.go
@@ -1,0 +1,232 @@
+// +build unit
+
+/*
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+Copyright 2016 Intel Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package processor
+
+import (
+	"bytes"
+	"encoding/gob"
+	"regexp"
+	"testing"
+
+	"github.com/intelsdi-x/snap/control/plugin"
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/intelsdi-x/snap/control/plugin/cpolicy"
+	"github.com/intelsdi-x/snap/core"
+	"github.com/intelsdi-x/snap/core/ctypes"
+)
+
+func TestMeta(t *testing.T) {
+	Convey("Meta should return plugin meta data", t, func() {
+		meta := Meta()
+		So(meta.Name, ShouldEqual, pluginName)
+		So(meta.Version, ShouldEqual, pluginVersion)
+		So(meta.Type, ShouldResemble, pluginType)
+	})
+}
+
+func TestNew(t *testing.T) {
+	proc := New()
+	Convey("Create ns-filter processor", t, func() {
+		Convey("So proc should not be nil", func() {
+			So(proc, ShouldNotBeNil)
+		})
+		Convey("So proc should be of type processor", func() {
+			So(proc, ShouldHaveSameTypeAs, &Processor{})
+		})
+	})
+}
+
+func TestPolicyProperConfig(t *testing.T) {
+	Convey("proc.GetConfigPolicy should return a config policy", t, func() {
+		proc := New()
+		configPolicy, _ := proc.GetConfigPolicy()
+		Convey("So config policy should be a cpolicy.ConfigPolicy", func() {
+			So(configPolicy, ShouldHaveSameTypeAs, &cpolicy.ConfigPolicy{})
+		})
+
+		Convey("Proper config provided", func() {
+			testConfig := make(map[string]ctypes.ConfigValue)
+			testConfig["expression"] = ctypes.ConfigValueStr{Value: "foo"}
+			testConfig["tag"] = ctypes.ConfigValueStr{Value: "bar"}
+			cfg, errs := configPolicy.Get([]string{"/"}).Process(testConfig)
+
+			Convey("So config policy should process testConfig and return a config", func() {
+				So(cfg, ShouldNotBeNil)
+			})
+			Convey("So testConfig processing should return no errors", func() {
+				So(errs.HasErrors(), ShouldBeFalse)
+			})
+		})
+	})
+}
+
+func TestPolicyBadConfig(t *testing.T) {
+	Convey("proc.GetConfigPolicy should return a config policy", t, func() {
+		proc := New()
+		configPolicy, _ := proc.GetConfigPolicy()
+		Convey("So config policy should be a cpolicy.ConfigPolicy", func() {
+			So(configPolicy, ShouldHaveSameTypeAs, &cpolicy.ConfigPolicy{})
+		})
+
+		Convey("Expression is not provided", func() {
+			testConfigBad := make(map[string]ctypes.ConfigValue)
+			testConfigBad["exp"] = ctypes.ConfigValueStr{Value: "foo"}
+			testConfigBad["tag"] = ctypes.ConfigValueStr{Value: "bar"}
+			cfg, errs := configPolicy.Get([]string{"/"}).Process(testConfigBad)
+
+			Convey("So config policy should process testConfigBad and return a config", func() {
+				So(cfg, ShouldBeNil)
+			})
+			Convey("So testConfig processing should return no errors", func() {
+				So(errs.HasErrors(), ShouldBeTrue)
+			})
+		})
+
+		Convey("Tag is not provided", func() {
+			testConfigBad := make(map[string]ctypes.ConfigValue)
+			testConfigBad["expression"] = ctypes.ConfigValueStr{Value: "foo"}
+			cfg, errs := configPolicy.Get([]string{"/"}).Process(testConfigBad)
+
+			Convey("So config policy should process testConfigBad and return a config", func() {
+				So(cfg, ShouldBeNil)
+			})
+			Convey("So testConfig processing should return no errors", func() {
+				So(errs.HasErrors(), ShouldBeTrue)
+			})
+		})
+
+		Convey("Expression and Tag are not provided", func() {
+			testConfigBad := map[string]ctypes.ConfigValue{}
+			cfg, errs := configPolicy.Get([]string{"/"}).Process(testConfigBad)
+
+			Convey("So config policy should process testConfigBad and return a config", func() {
+				So(cfg, ShouldBeNil)
+			})
+			Convey("So testConfig processing should return no errors", func() {
+				So(errs.HasErrors(), ShouldBeTrue)
+			})
+		})
+	})
+}
+
+func TestProcess(t *testing.T) {
+	Convey("Filtering metrics with host IP in namespace", t, func() {
+		metrics := []plugin.MetricType{
+			plugin.MetricType{
+				Namespace_: core.NewNamespace("intel", "foo", "1.1.1.2", "bar"),
+				Tags_:      map[string]string{},
+			},
+			plugin.MetricType{
+				Namespace_: core.NewNamespace("intel", "foo", "100.1.1.100", "bar"),
+				Tags_:      map[string]string{"faz": "qaz"},
+			},
+		}
+
+		expected := []plugin.MetricType{
+			plugin.MetricType{
+				Namespace_: core.NewNamespace("intel", "foo", "bar"),
+				Tags_:      map[string]string{"ip": "1.1.1.2"},
+			},
+			plugin.MetricType{
+				Namespace_: core.NewNamespace("intel", "foo", "bar"),
+				Tags_:      map[string]string{"faz": "qaz", "ip": "100.1.1.100"},
+			},
+		}
+
+		var buf bytes.Buffer
+		enc := gob.NewEncoder(&buf)
+		enc.Encode(metrics)
+
+		config := make(map[string]ctypes.ConfigValue)
+		config["expression"] = ctypes.ConfigValueStr{Value: `([0-9]{1,3}\.){3}([0-9]{1,3})`}
+		config["tag"] = ctypes.ConfigValueStr{Value: "ip"}
+
+		processor := New()
+		contentType, content, err := processor.Process("gob", buf.Bytes(), config)
+
+		var decoded []plugin.MetricType
+		dec := gob.NewDecoder(bytes.NewBuffer(content))
+		dec.Decode(&decoded)
+
+		So(contentType, ShouldEqual, "gob")
+		So(decoded, ShouldResemble, expected)
+		So(err, ShouldBeNil)
+
+	})
+}
+
+func TestFilter(t *testing.T) {
+	re, _ := regexp.Compile(`([0-9]{1,3}\.){3}([0-9]{1,3})`)
+	Convey("Filter metrics from unwanted parts", t, func() {
+		Convey("Nothing to remove", func() {
+			metrics := []plugin.MetricType{
+				plugin.MetricType{
+					Namespace_: core.NewNamespace("intel", "foo", "bar"),
+					Tags_:      map[string]string{},
+				},
+			}
+			filter(metrics, re, "ip")
+			So(metrics[0].Namespace().String(), ShouldEqual, core.NewNamespace("intel", "foo", "bar").String())
+			So(metrics[0].Tags(), ShouldResemble, map[string]string{})
+		})
+
+		Convey("Remove IP 1.1.1.2, add as tag", func() {
+			metrics := []plugin.MetricType{
+				plugin.MetricType{
+					Namespace_: core.NewNamespace("intel", "foo", "1.1.1.2", "bar"),
+					Tags_:      map[string]string{},
+				},
+			}
+
+			filter(metrics, re, "ip")
+			So(metrics[0].Namespace().String(), ShouldEqual, core.NewNamespace("intel", "foo", "bar").String())
+			So(metrics[0].Tags(), ShouldResemble, map[string]string{"ip": "1.1.1.2"})
+		})
+
+		Convey("Remove IP 10.255.255.100, add as tag", func() {
+			metrics := []plugin.MetricType{
+				plugin.MetricType{
+					Namespace_: core.NewNamespace("intel", "foo", "10.255.255.100", "bar"),
+					Tags_:      map[string]string{},
+				},
+			}
+
+			filter(metrics, re, "ip")
+			So(metrics[0].Namespace().String(), ShouldEqual, core.NewNamespace("intel", "foo", "bar").String())
+			So(metrics[0].Tags(), ShouldResemble, map[string]string{"ip": "10.255.255.100"})
+		})
+
+		Convey("Remove IP 100.1.1.100, add as tag, preserve tags", func() {
+			metrics := []plugin.MetricType{
+				plugin.MetricType{
+					Namespace_: core.NewNamespace("intel", "foo", "100.1.1.100", "bar"),
+					Tags_:      map[string]string{"faz": "qaz"},
+				},
+			}
+
+			filter(metrics, re, "ip")
+			So(metrics[0].Namespace().String(), ShouldEqual, core.NewNamespace("intel", "foo", "bar").String())
+			So(metrics[0].Tags(), ShouldResemble, map[string]string{"faz": "qaz", "ip": "100.1.1.100"})
+		})
+
+	})
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+
+GITVERSION=`git describe --always`
+SOURCEDIR=$1
+BUILDDIR=$SOURCEDIR/build
+PLUGIN=`echo $SOURCEDIR | grep -oh "snap-.*"`
+ROOTFS=$BUILDDIR/rootfs
+BUILDCMD='go build -a -ldflags "-w"'
+
+echo
+echo "****  Snap Plugin Build  ****"
+echo
+
+# Disable CGO for builds
+export CGO_ENABLED=0
+
+# Clean build bin dir
+rm -rf $ROOTFS/*
+
+# Make dir
+mkdir -p $ROOTFS
+
+# Build plugin
+echo "Source Dir = $SOURCEDIR"
+echo "Building Snap Plugin: $PLUGIN"
+$BUILDCMD -o $ROOTFS/$PLUGIN
+

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,83 @@
+#!/bin/bash -e
+# The script does automatic checking on a Go package and its sub-packages, including:
+# 1. gofmt         (http://golang.org/cmd/gofmt/)
+# 2. goimports     (https://github.com/bradfitz/goimports)
+# 3. golint        (https://github.com/golang/lint)
+# 4. go vet        (http://golang.org/cmd/vet)
+# 5. race detector (http://blog.golang.org/race-detector)
+# 6. test coverage (http://blog.golang.org/cover)
+
+# Capture what test we should run
+TEST_SUITE=$1
+
+if [[ $TEST_SUITE == "unit" ]]; then
+	go get github.com/axw/gocov/gocov
+	go get github.com/mattn/goveralls
+	go get -u github.com/golang/lint/golint
+	go get golang.org/x/tools/cmd/goimports
+	go get github.com/smartystreets/goconvey/convey
+	go get golang.org/x/tools/cmd/cover
+
+	COVERALLS_TOKEN=t47LG6BQsfLwb9WxB56hXUezvwpED6D11
+	TEST_DIRS="main.go processor/"
+	VET_DIRS=". ./processor/..."
+
+	set -e
+
+	# Automatic checks
+	echo "gofmt"
+	test -z "$(gofmt -l -d $TEST_DIRS | tee /dev/stderr)"
+
+	echo "goimports"
+	test -z "$(goimports -l -d $TEST_DIRS | tee /dev/stderr)"
+
+	# Useful but should not fail on link per: https://github.com/golang/lint
+	# "The suggestions made by golint are exactly that: suggestions. Golint is not perfect,
+	# and has both false positives and false negatives. Do not treat its output as a gold standard.
+	# We will not be adding pragmas or other knobs to suppress specific warnings, so do not expect
+	# or require code to be completely "lint-free". In short, this tool is not, and will never be,
+	# trustworthy enough for its suggestions to be enforced automatically, for example as part of
+	# a build process"
+	# echo "golint"
+	# golint ./...
+
+	echo "go vet"
+	go vet $VET_DIRS
+	# go test -race ./... - Lets disable for now
+
+	# Run test coverage on each subdirectories and merge the coverage profile.
+	echo "mode: count" > profile.cov
+
+	# Standard go tooling behavior is to ignore dirs with leading underscors
+	for dir in $(find . -maxdepth 10 -not -path './.git*' -not -path '*/_*' -not -path './examples/*' -not -path './scripts/*' -not -path './build/*' -not -path './Godeps/*' -type d);
+	do
+		if ls $dir/*.go &> /dev/null; then
+	    		go test --tags=unit -covermode=count -coverprofile=$dir/profile.tmp $dir
+	    		if [ -f $dir/profile.tmp ]
+	    		then
+	        		cat $dir/profile.tmp | tail -n +2 >> profile.cov
+	        		rm $dir/profile.tmp
+	    		fi
+		fi
+	done
+
+	go tool cover -func profile.cov
+
+	# Disabled Coveralls.io for now
+	# To submit the test coverage result to coveralls.io,
+	# use goveralls (https://github.com/mattn/goveralls)
+	# goveralls -coverprofile=profile.cov -service=travis-ci -repotoken t47LG6BQsfLwb9WxB56hXUezvwpED6D11
+	#
+	# If running inside Travis we update coveralls. We don't want his happening on Macs
+	# if [ "$TRAVIS" == "true" ]
+	# then
+	#     n=1
+	#     until [ $n -ge 6 ]
+	#     do
+	#         echo "posting to coveralls attempt $n of 5"
+	#         goveralls -v -coverprofile=profile.cov -service travis.ci -repotoken $COVERALLS_TOKEN && break
+	#         n=$[$n+1]
+	#         sleep 30
+	#     done
+	# fi
+fi


### PR DESCRIPTION
Ns-filter processor tries to compile provided regular expression from config item "expression" and match each namespace element to it.
If namespace element matches, it will be removed from the metric namespace and turned into tag with key provided in config item "tag".
